### PR TITLE
Add 'Lain-lain' category support for products

### DIFF
--- a/app/Http/Controllers/purchasing/ProdukController.php
+++ b/app/Http/Controllers/purchasing/ProdukController.php
@@ -112,7 +112,8 @@ class ProdukController extends Controller
                     COUNT(*) as totalProduk,
                     COUNT(CASE WHEN kategori = "Elektronik" THEN 1 END) as produkElektronik,
                     COUNT(CASE WHEN kategori = "Meubel" THEN 1 END) as produkMeubel,
-                    COUNT(CASE WHEN kategori = "Mesin" THEN 1 END) as produkMesin
+                    COUNT(CASE WHEN kategori = "Mesin" THEN 1 END) as produkMesin,
+                    COUNT(CASE WHEN kategori = "Lain-lain" THEN 1 END) as produkLainLain
                 ')
                 ->first();
                 
@@ -121,6 +122,7 @@ class ProdukController extends Controller
                 'produkElektronik' => $stats->produkElektronik,
                 'produkMeubel' => $stats->produkMeubel,
                 'produkMesin' => $stats->produkMesin,
+                'produkLainLain' => $stats->produkLainLain,
             ];
         });
     }

--- a/resources/views/pages/produk.blade.php
+++ b/resources/views/pages/produk.blade.php
@@ -76,7 +76,7 @@
 </div>
 
 <!-- Stats Cards -->
-<div class="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 lg:gap-6 mb-6 sm:mb-8">
+<div class="grid grid-cols-2 lg:grid-cols-5 gap-3 sm:gap-4 lg:gap-6 mb-6 sm:mb-8">
     <div class="bg-white rounded-xl sm:rounded-2xl shadow-lg p-3 sm:p-4 lg:p-6 border border-gray-100">
         <div class="flex flex-col sm:flex-row sm:items-center">
             <div class="p-2 sm:p-3 rounded-lg sm:rounded-xl bg-red-100 mb-2 sm:mb-0 sm:mr-4 w-fit">
@@ -118,6 +118,17 @@
             <div class="min-w-0">
                 <h3 class="text-xs sm:text-sm lg:text-lg font-semibold text-gray-800 truncate">Meubel</h3>
                 <p class="text-lg sm:text-xl lg:text-2xl font-bold text-yellow-600">{{ $produkMeubel }}</p>
+            </div>
+        </div>
+    </div>
+    <div class="bg-white rounded-xl sm:rounded-2xl shadow-lg p-3 sm:p-4 lg:p-6 border border-gray-100">
+        <div class="flex flex-col sm:flex-row sm:items-center">
+            <div class="p-2 sm:p-3 rounded-lg sm:rounded-xl bg-purple-100 mb-2 sm:mb-0 sm:mr-4 w-fit">
+                <i class="fas fa-ellipsis-h text-purple-600 text-sm sm:text-lg lg:text-xl"></i>
+            </div>
+            <div class="min-w-0">
+                <h3 class="text-xs sm:text-sm lg:text-lg font-semibold text-gray-800 truncate">Lain-lain</h3>
+                <p class="text-lg sm:text-xl lg:text-2xl font-bold text-purple-600">{{ $produkLainLain }}</p>
             </div>
         </div>
     </div>
@@ -245,14 +256,6 @@
         @if($produk->count() > 0)
             <div class="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-3 sm:gap-6">
                 @foreach($produk as $item)
-                    @php
-                        $badgeClass = match($item->kategori) {
-                            'Elektronik' => 'bg-blue-100 text-blue-800',
-                            'Mesin'      => 'bg-green-100 text-green-800',
-                            'Meubel'     => 'bg-yellow-100 text-yellow-800',
-                            default      => 'bg-gray-100 text-gray-800',
-                        };
-                    @endphp
                     <div class="bg-white border border-gray-200 rounded-xl shadow-sm hover:shadow-lg transition-all duration-300 overflow-hidden group cursor-pointer flex flex-col" onclick="showProductDetail({{ $item->id_barang }})">
                         <div class="relative">
                             <!-- Product Image -->
@@ -269,7 +272,13 @@
                             </div>
                             <!-- Category Badge -->
                             <div class="absolute top-2 right-2">
-                                <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full {{ $badgeClass }}">
+                                <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full
+                                    @if($item->kategori == 'Elektronik') bg-blue-100 text-blue-800
+                                    @elseif($item->kategori == 'Mesin') bg-green-100 text-green-800
+                                    @elseif($item->kategori == 'Meubel') bg-yellow-100 text-yellow-800
+                                    @elseif($item->kategori == 'Lain-lain') bg-purple-100 text-purple-800
+                                    @else bg-gray-100 text-gray-800
+                                    @endif">
                                     {{ $item->kategori }}
                                 </span>
                             </div>
@@ -354,9 +363,8 @@
                     if (hasFileSpec) {
                         const fileLink = document.getElementById('detailSpesifikasiFileLink');
                         const fileName = document.getElementById('detailSpesifikasiFileName');
-                        
-                        fileLink.href = `{{ asset('storage') }}/${produk.spesifikasi_file}`;
-                        fileName.textContent = produk.spesifikasi_file.split('/').pop() || 'Lihat File';
+                        fileLink.href = `/storage/${produk.spesifikasi_file}`;
+                        fileName.textContent = produk.spesifikasi_file.split('/').pop();
                         fileContainer.style.display = 'block';
                     } else {
                         fileContainer.style.display = 'none';
@@ -396,6 +404,9 @@
                             break;
                         case 'Meubel':
                             categoryBadge.classList.add('bg-yellow-100', 'text-yellow-800');
+                            break;
+                        case 'Lain-lain':
+                            categoryBadge.classList.add('bg-purple-100', 'text-purple-800');
                             break;
                         default:
                             categoryBadge.classList.add('bg-gray-100', 'text-gray-800');

--- a/resources/views/pages/purchasing/produk.blade.php
+++ b/resources/views/pages/purchasing/produk.blade.php
@@ -76,7 +76,7 @@
 </div>
 
 <!-- Stats Cards -->
-<div class="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 lg:gap-6 mb-6 sm:mb-8">
+<div class="grid grid-cols-2 lg:grid-cols-5 gap-3 sm:gap-4 lg:gap-6 mb-6 sm:mb-8">
     <div class="bg-white rounded-xl sm:rounded-2xl shadow-lg p-3 sm:p-4 lg:p-6 border border-gray-100">
         <div class="flex flex-col sm:flex-row sm:items-center">
             <div class="p-2 sm:p-3 rounded-lg sm:rounded-xl bg-red-100 mb-2 sm:mb-0 sm:mr-4 w-fit">
@@ -118,6 +118,17 @@
             <div class="min-w-0">
                 <h3 class="text-xs sm:text-sm lg:text-lg font-semibold text-gray-800 truncate">Meubel</h3>
                 <p class="text-lg sm:text-xl lg:text-2xl font-bold text-yellow-600">{{ $produkMeubel }}</p>
+            </div>
+        </div>
+    </div>
+    <div class="bg-white rounded-xl sm:rounded-2xl shadow-lg p-3 sm:p-4 lg:p-6 border border-gray-100">
+        <div class="flex flex-col sm:flex-row sm:items-center">
+            <div class="p-2 sm:p-3 rounded-lg sm:rounded-xl bg-purple-100 mb-2 sm:mb-0 sm:mr-4 w-fit">
+                <i class="fas fa-ellipsis-h text-purple-600 text-sm sm:text-lg lg:text-xl"></i>
+            </div>
+            <div class="min-w-0">
+                <h3 class="text-xs sm:text-sm lg:text-lg font-semibold text-gray-800 truncate">Lain-lain</h3>
+                <p class="text-lg sm:text-xl lg:text-2xl font-bold text-purple-600">{{ $produkLainLain }}</p>
             </div>
         </div>
     </div>
@@ -265,6 +276,7 @@
                                     @if($item->kategori == 'Elektronik') bg-blue-100 text-blue-800
                                     @elseif($item->kategori == 'Mesin') bg-green-100 text-green-800
                                     @elseif($item->kategori == 'Meubel') bg-yellow-100 text-yellow-800
+                                    @elseif($item->kategori == 'Lain-lain') bg-purple-100 text-purple-800
                                     @else bg-gray-100 text-gray-800
                                     @endif">
                                     {{ $item->kategori }}
@@ -392,6 +404,9 @@
                             break;
                         case 'Meubel':
                             categoryBadge.classList.add('bg-yellow-100', 'text-yellow-800');
+                            break;
+                        case 'Lain-lain':
+                            categoryBadge.classList.add('bg-purple-100', 'text-purple-800');
                             break;
                         default:
                             categoryBadge.classList.add('bg-gray-100', 'text-gray-800');


### PR DESCRIPTION
Added handling for the 'Lain-lain' product category in product statistics, UI stats cards, category badges, and product detail modals. Updated both main and purchasing product views to display and style the new category appropriately.